### PR TITLE
Fix stock calculation in MovimientosService

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
@@ -16,6 +16,9 @@ public interface TransaccionAlmacenRepo extends JpaRepository<Movimiento, Intege
 
     List<Movimiento> findMovimientosByCantidad(Double cantidad);
 
+    // Get movimientos filtered by product ID
+    List<Movimiento> findByProducto_ProductoId(String productoId);
+
     // New method
     Page<Movimiento> findByProducto_ProductoIdOrderByFechaMovimientoDesc(String productoId, Pageable pageable);
 

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosService.java
@@ -84,19 +84,17 @@ public class MovimientosService {
     }
 
     public Optional<ProductoStockDTO> getStockOf2(String producto_id){
-        try {
-            // Intentar convertir a double solo si es necesario para la compatibilidad con el método existente
-            double productoIdDouble = Double.parseDouble(producto_id);
-            List<Movimiento> movs = transaccionAlmacenRepo.findMovimientosByCantidad(productoIdDouble);
-            if(!movs.isEmpty()){
-                double productoStock = movs.stream().mapToDouble(Movimiento::getCantidad).sum();
-                return Optional.of(new ProductoStockDTO(movs.getFirst().getProducto(), productoStock));
-            }
-        } catch (NumberFormatException e) {
-            // Si el ID no es numérico, no podemos usar findMovimientosByCantidad
-            // En este caso, podríamos buscar por el ID directamente si hay un método disponible
+        Optional<Producto> optionalProducto = productoRepo.findByProductoId(producto_id);
+        if(optionalProducto.isEmpty()){
+            return Optional.empty();
         }
-        return Optional.empty();
+
+        List<Movimiento> movimientos = transaccionAlmacenRepo.findByProducto_ProductoId(producto_id);
+        double productoStock = movimientos.stream()
+                .mapToDouble(Movimiento::getCantidad)
+                .sum();
+
+        return Optional.of(new ProductoStockDTO(optionalProducto.get(), productoStock));
     }
 
 

--- a/src/test/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosServiceTest.java
+++ b/src/test/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosServiceTest.java
@@ -1,0 +1,65 @@
+package lacosmetics.planta.lacmanufacture.service.inventarios;
+
+import lacosmetics.planta.lacmanufacture.model.dto.ProductoStockDTO;
+import lacosmetics.planta.lacmanufacture.model.inventarios.Movimiento;
+import lacosmetics.planta.lacmanufacture.model.producto.Producto;
+import lacosmetics.planta.lacmanufacture.repo.compras.OrdenCompraRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.LoteRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.TransaccionAlmacenHeaderRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.TransaccionAlmacenRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.MaterialRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.ProductoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.SemiTerminadoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.TerminadoRepo;
+import lacosmetics.planta.lacmanufacture.repo.usuarios.UserRepository;
+import lacosmetics.planta.lacmanufacture.service.contabilidad.ContabilidadService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+class MovimientosServiceTest {
+
+    @Test
+    void getStockOf2ReturnsCorrectStock() {
+        TransaccionAlmacenRepo transRepo = Mockito.mock(TransaccionAlmacenRepo.class);
+        ProductoRepo prodRepo = Mockito.mock(ProductoRepo.class);
+        TransaccionAlmacenHeaderRepo headerRepo = Mockito.mock(TransaccionAlmacenHeaderRepo.class);
+        OrdenCompraRepo ordenRepo = Mockito.mock(OrdenCompraRepo.class);
+        SemiTerminadoRepo semiRepo = Mockito.mock(SemiTerminadoRepo.class);
+        TerminadoRepo termRepo = Mockito.mock(TerminadoRepo.class);
+        MaterialRepo materialRepo = Mockito.mock(MaterialRepo.class);
+        LoteRepo loteRepo = Mockito.mock(LoteRepo.class);
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+        ContabilidadService contService = Mockito.mock(ContabilidadService.class);
+
+        MovimientosService service = new MovimientosService(transRepo, prodRepo, headerRepo,
+                ordenRepo, semiRepo, termRepo, materialRepo,
+                loteRepo, userRepo, contService);
+
+        Producto producto = new Producto();
+        producto.setProductoId("P1");
+
+        when(prodRepo.findByProductoId("P1")).thenReturn(Optional.of(producto));
+
+        Movimiento m1 = new Movimiento();
+        m1.setCantidad(5);
+        m1.setProducto(producto);
+
+        Movimiento m2 = new Movimiento();
+        m2.setCantidad(3);
+        m2.setProducto(producto);
+
+        when(transRepo.findByProducto_ProductoId("P1")).thenReturn(List.of(m1, m2));
+
+        Optional<ProductoStockDTO> result = service.getStockOf2("P1");
+
+        assertTrue(result.isPresent());
+        assertEquals(8.0, result.get().getStock());
+        assertEquals("P1", result.get().getProducto().getProductoId());
+    }
+}


### PR DESCRIPTION
## Summary
- fix `getStockOf2` to query by product ID instead of quantity
- expose new repo method `findByProducto_ProductoId`
- add unit test for the fixed logic

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6863ebe4b6388332b1741633720cab3d