### PR TITLE
Disallow login and recovery for inactive users

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/users/AuthService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/users/AuthService.java
@@ -11,6 +11,7 @@ import lacosmetics.planta.lacmanufacture.service.commons.EmailService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -48,6 +49,13 @@ public class AuthService {
     @Transactional
     public Map<String, String> authenticateUser(String username, String password) {
         try {
+            // Verify that the user exists and is active before authenticating
+            Optional<User> userOpt = userRepository.findByUsername(username);
+            if (userOpt.isEmpty() || userOpt.get().getEstado() != 1) {
+                log.info("Login attempt for inactive or non-existent user: {}", username);
+                throw new BadCredentialsException("User is inactive");
+            }
+
             // Create authentication object
             UsernamePasswordAuthenticationToken authRequest = new UsernamePasswordAuthenticationToken(
                     username,
@@ -93,6 +101,12 @@ public class AuthService {
         }
 
         User user = userOpt.get();
+
+        // Only allow reset for active users
+        if (user.getEstado() != 1) {
+            log.info("Password reset requested for inactive user: {}", username);
+            return false;
+        }
 
         // Delete any existing tokens for this user
         passwordResetTokenRepository.deleteByUser(user);

--- a/src/test/java/lacosmetics/planta/lacmanufacture/service/users/AuthServiceTest.java
+++ b/src/test/java/lacosmetics/planta/lacmanufacture/service/users/AuthServiceTest.java
@@ -1,0 +1,65 @@
+package lacosmetics.planta.lacmanufacture.service.users;
+
+import lacosmetics.planta.lacmanufacture.model.users.User;
+import lacosmetics.planta.lacmanufacture.model.users.auth.PasswordResetToken;
+import lacosmetics.planta.lacmanufacture.repo.usuarios.PasswordResetTokenRepository;
+import lacosmetics.planta.lacmanufacture.repo.usuarios.UserRepository;
+import lacosmetics.planta.lacmanufacture.security.JwtTokenProvider;
+import lacosmetics.planta.lacmanufacture.service.commons.EmailService;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+class AuthServiceTest {
+
+    @Test
+    void authenticateUser_inactiveUser_throwsException() {
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+        AuthenticationManager authManager = Mockito.mock(AuthenticationManager.class);
+        JwtTokenProvider tokenProvider = Mockito.mock(JwtTokenProvider.class);
+        PasswordResetTokenRepository tokenRepo = Mockito.mock(PasswordResetTokenRepository.class);
+        EmailService emailService = Mockito.mock(EmailService.class);
+
+        AuthService service = new AuthService(userRepo, authManager, tokenProvider, tokenRepo, emailService);
+
+        User inactive = new User();
+        inactive.setEstado(2);
+        when(userRepo.findByUsername("user")).thenReturn(Optional.of(inactive));
+
+        assertThrows(AuthenticationException.class, () -> service.authenticateUser("user", "pass"));
+        verify(authManager, never()).authenticate(any());
+    }
+
+    @Test
+    void requestPasswordReset_inactiveUser_returnsFalse() {
+        UserRepository userRepo = Mockito.mock(UserRepository.class);
+        AuthenticationManager authManager = Mockito.mock(AuthenticationManager.class);
+        JwtTokenProvider tokenProvider = Mockito.mock(JwtTokenProvider.class);
+        PasswordResetTokenRepository tokenRepo = Mockito.mock(PasswordResetTokenRepository.class);
+        EmailService emailService = Mockito.mock(EmailService.class);
+
+        AuthService service = new AuthService(userRepo, authManager, tokenProvider, tokenRepo, emailService);
+
+        User inactive = new User();
+        inactive.setEstado(2);
+        inactive.setUsername("user");
+        inactive.setNombreCompleto("User Test");
+        inactive.setEmail("user@test.com");
+        when(userRepo.findByEmail("user@test.com")).thenReturn(Optional.of(inactive));
+
+        boolean result = service.requestPasswordReset("user@test.com");
+
+        assertFalse(result);
+        verify(tokenRepo, never()).save(any(PasswordResetToken.class));
+        verify(emailService, never()).sendHtmlEmail(anyString(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
## Summary
- check user status before allowing login
- prevent reset password emails when user is inactive
- test AuthService for inactive users

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686ff880d05c8332a6272636f8bb3645