### PR TITLE
Add validation constraints for ProcesoRecurso cantidad

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoRecurso.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoRecurso.java
@@ -1,6 +1,8 @@
 package lacosmetics.planta.lacmanufacture.model.producto.procesos;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -25,6 +27,9 @@ public class ProcesoRecurso {
     private RecursoProduccion recurso;
 
     // Integer quantity of fixed assets required for this process
+    @NotNull
+    @Min(1)
+    @Column(nullable = false)
     private Integer cantidad;
     
     // Optional: Additional attributes

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/procesos/ProcesoRecursoService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/procesos/ProcesoRecursoService.java
@@ -1,11 +1,13 @@
 package lacosmetics.planta.lacmanufacture.service.productos.procesos;
 
+import jakarta.validation.Valid;
 import lacosmetics.planta.lacmanufacture.model.producto.procesos.ProcesoRecurso;
 import lacosmetics.planta.lacmanufacture.repo.producto.procesos.ProcesoRecursoRepo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,12 +15,13 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@Validated
 public class ProcesoRecursoService {
 
     private final ProcesoRecursoRepo procesoRecursoRepo;
 
     @Transactional
-    public ProcesoRecurso saveProcesoRecurso(ProcesoRecurso procesoRecurso) {
+    public ProcesoRecurso saveProcesoRecurso(@Valid ProcesoRecurso procesoRecurso) {
         log.info("Guardando relación proceso-recurso");
         return procesoRecursoRepo.save(procesoRecurso);
     }


### PR DESCRIPTION
## Summary
- enforce non-null positive quantity in ProcesoRecurso with column constraint
- validate ProcesoRecurso entities via service-level Bean Validation

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_689dee22ec4c83328d749b907e4e499c