### PR TITLE
Set default inventareable flag and add migration

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/Producto.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/Producto.java
@@ -86,8 +86,8 @@ public abstract class Producto {
      * true: si pasa por almacen.
      * false: no pasa por alamacen
      *
-     */
-    @Column(columnDefinition = "boolean default true")
-    private boolean inventareable;
+    */
+    @Column
+    private boolean inventareable = true;
 
 }

--- a/src/main/resources/db/migration/V12__add_inventareable_default_true_20250821.sql
+++ b/src/main/resources/db/migration/V12__add_inventareable_default_true_20250821.sql
@@ -1,0 +1,3 @@
+-- Ensure inventareable column exists with default TRUE
+ALTER TABLE productos ADD COLUMN IF NOT EXISTS inventareable BOOLEAN DEFAULT TRUE;
+ALTER TABLE productos ALTER COLUMN inventareable SET DEFAULT TRUE;


### PR DESCRIPTION
## Summary
- Initialize producto field `inventareable` to `true` and simplify column mapping
- Add Flyway migration to ensure `inventareable` column has default `TRUE`

## Testing
- `./gradlew test` *(fails: constructor MovimientosService cannot be applied to given types)*

------
https://chatgpt.com/codex/tasks/task_e_68a644f512f48332b01ad5e79cd81cd7