### PR TITLE
Add configurable mapping for product bulk uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ scp -i "filename" -r "source folder" "destination host":"destination folder"
 ```
 
 
-## Scan Entidades 
+## Scan Entidades
 
 el script scanEntities.jsh es un script para jshell que
 realiza un resumen en txt en entity-summary.txt de las
@@ -37,3 +37,29 @@ entidades del backend en el package model.
 ```
 jshell --startup PRINTING scanEntities.jsh
 ```
+
+## Carga masiva de productos
+
+El endpoint `POST /api/bulk-upload/products` permite cargar un archivo Excel con
+productos y opcionalmente un objeto `mapping` que define la posición de las
+columnas. Cuando no se envía, se utilizan los índices predeterminados
+`(1,3,6,7,8,9,10)`.
+
+Ejemplo de llamada con mapeo personalizado:
+
+```bash
+curl -X POST \
+  -F "file=@inventario.xlsx" \
+  -F 'mapping={"descripcion":0,"unidadMedida":2,"stock":1,"productoId":3,"iva":4,"puntoReorden":5,"costoUnitario":6};type=application/json' \
+  http://localhost:8080/api/bulk-upload/products
+```
+
+Campos del mapeo:
+
+- `descripcion`: índice de la descripción del producto.
+- `unidadMedida`: índice de la unidad de medida.
+- `stock`: índice del stock inicial.
+- `productoId`: índice del identificador del producto.
+- `iva`: índice del IVA del producto.
+- `puntoReorden`: índice del punto de reorden.
+- `costoUnitario`: índice del costo unitario.

--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/commons/bulkupload/MaterialBulkUploadMappingDTO.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/commons/bulkupload/MaterialBulkUploadMappingDTO.java
@@ -1,0 +1,34 @@
+package lacosmetics.planta.lacmanufacture.model.dto.commons.bulkupload;
+
+import lombok.Data;
+
+/**
+ * DTO para definir el mapeo de columnas en la carga masiva de materiales.
+ * Cada propiedad representa el índice de la columna en el archivo Excel
+ * que contiene la información correspondiente. Los valores por defecto
+ * mantienen compatibilidad con el formato histórico.
+ */
+@Data
+public class MaterialBulkUploadMappingDTO {
+
+    /** Índice de la columna de descripción del producto. */
+    private int descripcion = 1;
+
+    /** Índice de la columna de unidad de medida. */
+    private int unidadMedida = 3;
+
+    /** Índice de la columna de stock inicial. */
+    private int stock = 6;
+
+    /** Índice de la columna del identificador del producto. */
+    private int productoId = 7;
+
+    /** Índice de la columna del IVA. */
+    private int iva = 8;
+
+    /** Índice de la columna del punto de reorden. */
+    private int puntoReorden = 9;
+
+    /** Índice de la columna del costo unitario. */
+    private int costoUnitario = 10;
+}

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/commons/BulkUploadResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/commons/BulkUploadResource.java
@@ -1,6 +1,7 @@
 package lacosmetics.planta.lacmanufacture.resource.commons;
 
 import lacosmetics.planta.lacmanufacture.model.dto.commons.bulkupload.BulkUploadResponseDTO;
+import lacosmetics.planta.lacmanufacture.model.dto.commons.bulkupload.MaterialBulkUploadMappingDTO;
 import lacosmetics.planta.lacmanufacture.service.commons.BulkUploadService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -49,9 +50,11 @@ public class BulkUploadResource {
      * @param file The file containing product data
      * @return Response with status of the upload operation or a file with detailed report
      */
-    @PostMapping("/products")
-    public ResponseEntity<?> bulkUploadProducts(@RequestParam("file") MultipartFile file) {
-        BulkUploadResponseDTO response = bulkUploadService.processBulkProductUpload(file);
+    @PostMapping(value = "/products", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<?> bulkUploadProducts(
+            @RequestPart("file") MultipartFile file,
+            @RequestPart(value = "mapping", required = false) MaterialBulkUploadMappingDTO mapping) {
+        BulkUploadResponseDTO response = bulkUploadService.processBulkProductUpload(file, mapping);
 
         // Siempre devolver el archivo de reporte
         HttpHeaders headers = new HttpHeaders();

--- a/src/test/java/lacosmetics/planta/lacmanufacture/service/commons/BulkUploadServiceTest.java
+++ b/src/test/java/lacosmetics/planta/lacmanufacture/service/commons/BulkUploadServiceTest.java
@@ -1,0 +1,122 @@
+package lacosmetics.planta.lacmanufacture.service.commons;
+
+import lacosmetics.planta.lacmanufacture.config.StorageProperties;
+import lacosmetics.planta.lacmanufacture.model.dto.commons.bulkupload.BulkUploadResponseDTO;
+import lacosmetics.planta.lacmanufacture.model.dto.commons.bulkupload.MaterialBulkUploadMappingDTO;
+import lacosmetics.planta.lacmanufacture.model.inventarios.TransaccionAlmacen;
+import lacosmetics.planta.lacmanufacture.model.producto.Material;
+import lacosmetics.planta.lacmanufacture.repo.compras.FacturaCompraRepo;
+import lacosmetics.planta.lacmanufacture.repo.compras.OrdenCompraRepo;
+import lacosmetics.planta.lacmanufacture.repo.compras.ProveedorRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.LoteRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.TransaccionAlmacenHeaderRepo;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.TransaccionAlmacenRepo;
+import lacosmetics.planta.lacmanufacture.repo.produccion.OrdenProduccionRepo;
+import lacosmetics.planta.lacmanufacture.repo.produccion.OrdenSeguimientoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.InsumoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.MaterialRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.ProductoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.SemiTerminadoRepo;
+import lacosmetics.planta.lacmanufacture.repo.producto.TerminadoRepo;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.ByteArrayOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+public class BulkUploadServiceTest {
+
+    @Test
+    void bulkUploadWithCustomMapping() throws Exception {
+        // Crear un libro de Excel con columnas en orden distinto al predeterminado
+        Workbook workbook = new XSSFWorkbook();
+        Sheet sheet = workbook.createSheet("inventario");
+        Row header = sheet.createRow(0);
+        header.createCell(0).setCellValue("DESCRIPCION");
+        header.createCell(1).setCellValue("STOCK");
+        header.createCell(2).setCellValue("UNI/MEDIDAS");
+        header.createCell(3).setCellValue("NUEVO CODIGO");
+        header.createCell(4).setCellValue("IVA");
+        header.createCell(5).setCellValue("PUNTO DE REORDEN");
+        header.createCell(6).setCellValue("COSTO UNITARIO DEL PRODUCTO");
+        Row row = sheet.createRow(1);
+        row.createCell(0).setCellValue("Material A");
+        row.createCell(1).setCellValue(10);
+        row.createCell(2).setCellValue("KG");
+        row.createCell(3).setCellValue("me001");
+        row.createCell(4).setCellValue(19);
+        row.createCell(5).setCellValue(5);
+        row.createCell(6).setCellValue(1000);
+
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        workbook.write(bos);
+        workbook.close();
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "inventario.xlsx",
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                bos.toByteArray());
+
+        // Definir mapeo personalizado
+        MaterialBulkUploadMappingDTO mapping = new MaterialBulkUploadMappingDTO();
+        mapping.setDescripcion(0);
+        mapping.setStock(1);
+        mapping.setUnidadMedida(2);
+        mapping.setProductoId(3);
+        mapping.setIva(4);
+        mapping.setPuntoReorden(5);
+        mapping.setCostoUnitario(6);
+
+        // Crear mocks de dependencias
+        TransaccionAlmacenRepo transRepo = mock(TransaccionAlmacenRepo.class);
+        TransaccionAlmacenHeaderRepo transHeaderRepo = mock(TransaccionAlmacenHeaderRepo.class);
+        OrdenCompraRepo ordenCompraRepo = mock(OrdenCompraRepo.class);
+        FacturaCompraRepo facturaRepo = mock(FacturaCompraRepo.class);
+        ProveedorRepo proveedorRepo = mock(ProveedorRepo.class);
+        ProductoRepo productoRepo = mock(ProductoRepo.class);
+        MaterialRepo materialRepo = mock(MaterialRepo.class);
+        SemiTerminadoRepo semiTerminadoRepo = mock(SemiTerminadoRepo.class);
+        TerminadoRepo terminadoRepo = mock(TerminadoRepo.class);
+        InsumoRepo insumoRepo = mock(InsumoRepo.class);
+        OrdenProduccionRepo ordenProduccionRepo = mock(OrdenProduccionRepo.class);
+        OrdenSeguimientoRepo ordenSeguimientoRepo = mock(OrdenSeguimientoRepo.class);
+        LoteRepo loteRepo = mock(LoteRepo.class);
+        StorageProperties storageProperties = new StorageProperties();
+
+        BulkUploadService service = new BulkUploadService(
+                transRepo,
+                transHeaderRepo,
+                ordenCompraRepo,
+                facturaRepo,
+                proveedorRepo,
+                storageProperties,
+                productoRepo,
+                materialRepo,
+                semiTerminadoRepo,
+                terminadoRepo,
+                insumoRepo,
+                ordenProduccionRepo,
+                ordenSeguimientoRepo,
+                loteRepo);
+
+        BulkUploadResponseDTO response = service.processBulkProductUpload(file, mapping);
+
+        assertEquals(1, response.getSuccessCount());
+        verify(materialRepo).save(argThat((Material m) ->
+                m.getNombre().equals("Material A") && m.getProductoId().equals("me001")));
+        ArgumentCaptor<TransaccionAlmacen> captor = ArgumentCaptor.forClass(TransaccionAlmacen.class);
+        verify(transHeaderRepo).save(captor.capture());
+        TransaccionAlmacen ta = captor.getValue();
+        assertEquals(1, ta.getMovimientosTransaccion().size());
+        assertEquals(10d, ta.getMovimientosTransaccion().get(0).getCantidad());
+    }
+}

--- a/src/test/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosServiceTest.java
+++ b/src/test/java/lacosmetics/planta/lacmanufacture/service/inventarios/MovimientosServiceTest.java
@@ -11,6 +11,8 @@ import lacosmetics.planta.lacmanufacture.repo.producto.MaterialRepo;
 import lacosmetics.planta.lacmanufacture.repo.producto.ProductoRepo;
 import lacosmetics.planta.lacmanufacture.repo.producto.SemiTerminadoRepo;
 import lacosmetics.planta.lacmanufacture.repo.producto.TerminadoRepo;
+import lacosmetics.planta.lacmanufacture.repo.produccion.OrdenProduccionRepo;
+import lacosmetics.planta.lacmanufacture.repo.produccion.OrdenSeguimientoRepo;
 import lacosmetics.planta.lacmanufacture.repo.usuarios.UserRepository;
 import lacosmetics.planta.lacmanufacture.service.contabilidad.ContabilidadService;
 import org.junit.jupiter.api.Test;
@@ -36,10 +38,12 @@ class MovimientosServiceTest {
         LoteRepo loteRepo = Mockito.mock(LoteRepo.class);
         UserRepository userRepo = Mockito.mock(UserRepository.class);
         ContabilidadService contService = Mockito.mock(ContabilidadService.class);
+        OrdenProduccionRepo ordenProduccionRepo = Mockito.mock(OrdenProduccionRepo.class);
+        OrdenSeguimientoRepo ordenSeguimientoRepo = Mockito.mock(OrdenSeguimientoRepo.class);
 
         MovimientosService service = new MovimientosService(transRepo, prodRepo, headerRepo,
                 ordenRepo, semiRepo, termRepo, materialRepo,
-                loteRepo, userRepo, contService);
+                loteRepo, userRepo, contService, ordenProduccionRepo, ordenSeguimientoRepo);
 
         Material producto = new Material();
         producto.setProductoId("P1");


### PR DESCRIPTION
## Summary
- allow uploading products with a custom column mapping via new `MaterialBulkUploadMappingDTO`
- update bulk upload endpoint and service to use mapping with safe index validation and defaults
- document custom mapping usage and cover with unit test

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a73d01748883329f51b8e93893ebbb