### PR TITLE
feat: allow sheet selection in bulk upload and add debug logs

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/commons/bulkupload/MaterialBulkUploadMappingDTO.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/commons/bulkupload/MaterialBulkUploadMappingDTO.java
@@ -11,6 +11,9 @@ import lombok.Data;
 @Data
 public class MaterialBulkUploadMappingDTO {
 
+    /** Nombre de la hoja de cálculo que contiene los datos. */
+    private String sheetName = "inventario";
+
     /** Índice de la columna de descripción del producto. */
     private int descripcion = 1;
 


### PR DESCRIPTION
## Summary
- allow specifying the Excel sheet in `MaterialBulkUploadMappingDTO`
- log mapping and initial row values during bulk product upload for easier debugging

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a74ef828a083329d07b5f8c0e2c705