### PR TITLE
Align producto-proceso JSON references

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/SemiTerminado.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/SemiTerminado.java
@@ -1,6 +1,7 @@
 package lacosmetics.planta.lacmanufacture.model.producto;
 
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lacosmetics.planta.lacmanufacture.model.producto.receta.Insumo;
 import lacosmetics.planta.lacmanufacture.model.producto.procesos.ProcesoProduccionCompleto;
@@ -25,7 +26,7 @@ public class SemiTerminado extends Producto{
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "proceso_prod_id")
-    @com.fasterxml.jackson.annotation.JsonManagedReference(value = "semi-proceso")
+    @JsonManagedReference("producto-proceso")
     private ProcesoProduccionCompleto procesoProduccionCompleto;
 
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/Terminado.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/Terminado.java
@@ -1,5 +1,6 @@
 package lacosmetics.planta.lacmanufacture.model.producto;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import jakarta.persistence.*;
 import lacosmetics.planta.lacmanufacture.model.producto.receta.Insumo;
 import lacosmetics.planta.lacmanufacture.model.producto.procesos.ProcesoProduccionCompleto;
@@ -27,7 +28,7 @@ public class Terminado extends Producto{
 
     @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "proceso_prod_id")
-    @com.fasterxml.jackson.annotation.JsonManagedReference(value = "terminado-proceso")
+    @JsonManagedReference("producto-proceso")
     private ProcesoProduccionCompleto procesoProduccionCompleto;
 
     @ManyToOne

--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoProduccionCompleto.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoProduccionCompleto.java
@@ -25,6 +25,7 @@ public class ProcesoProduccionCompleto {
 
     @ManyToOne
     @JoinColumn(name = "producto_id")
+    @JsonBackReference("producto-proceso")
     private Producto producto;
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)


### PR DESCRIPTION
## Summary
- Ensure `ProcesoProduccionCompleto` uses `@JsonBackReference` for `Producto`
- Standardize `JsonManagedReference` names for `SemiTerminado` and `Terminado`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a7795ab4988332a3530050c0ce249a