### PR TITLE
feat: store process diagram json

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoProduccionCompleto.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/ProcesoProduccionCompleto.java
@@ -38,4 +38,7 @@ public class ProcesoProduccionCompleto {
 
     @Column(name = "rendimiento_teorico")
     private double rendimientoTeorico;
+
+    @Lob
+    private String diagramaJson;
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/nodo/ProcesoProduccionNode.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/producto/procesos/nodo/ProcesoProduccionNode.java
@@ -1,5 +1,6 @@
 package lacosmetics.planta.lacmanufacture.model.producto.procesos.nodo;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import jakarta.persistence.*;
 import lacosmetics.planta.lacmanufacture.model.producto.procesos.ProcesoProduccion;
 import lombok.Getter;
@@ -11,6 +12,7 @@ import java.util.List;
 @Table(name = "proceso_produccion_node")
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ProcesoProduccionNode {
 
     @Id

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
@@ -141,6 +141,13 @@ public class ProductoResource {
         return ResponseEntity.ok().body(productos);
     }
 
+    @GetMapping("/{productoId}")
+    public ResponseEntity<Producto> getProductoById(@PathVariable String productoId) {
+        return productoService.findProductoById(productoId)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
 
     @GetMapping("/{productoId}/insumos_with_stock")
     public ResponseEntity<List<InsumoWithStockDTO>> getInsumosWithStock(@PathVariable String productoId) {

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/ProductoService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/ProductoService.java
@@ -53,6 +53,11 @@ public class ProductoService {
         return productoRepo.findAll(PageRequest.of(page, size));
     }
 
+    @Transactional(readOnly = true)
+    public Optional<Producto> findProductoById(String productoId) {
+        return productoRepo.findById(productoId);
+    }
+
     /**
      * no longer to be used to save a materia prima
      * @param producto


### PR DESCRIPTION
## Summary
- persist process diagram JSON in `ProcesoProduccionCompleto`
- ignore unknown fields when deserializing `ProcesoProduccionNode`
- expose endpoint to fetch product with its process diagram

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a7c78b2d008332aa119be6d8d64171