### PR TITLE
Rename MASTER_CONFIGS module to MASTER_DIRECTIVES

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/users/Acceso.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/users/Acceso.java
@@ -44,7 +44,7 @@ public class Acceso {
         BINTELLIGENCE,
         CARGA_MASIVA, // nuevos endpoints de aca para abajo
         ADMINISTRACION_ALERTAS,
-        MASTER_CONFIGS,
+        MASTER_DIRECTIVES,
         CRONOGRAMA,
         ORGANIGRAMA,
         PAGOS_PROVEEDORES

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/commons/notificaciones/NotificacionesModulosService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/commons/notificaciones/NotificacionesModulosService.java
@@ -93,8 +93,8 @@ public class NotificacionesModulosService {
                     case ADMINISTRACION_ALERTAS:
                         notification = checkNotificacionesAdministracionAlertas(user);
                         break;
-                    case MASTER_CONFIGS:
-                        notification = checkNotificacionesMasterConfigs(user);
+                    case MASTER_DIRECTIVES:
+                        notification = checkNotificacionesMasterDirectives(user);
                         break;
                     case CRONOGRAMA:
                         notification = checkNotificacionesCronograma(user);
@@ -349,13 +349,13 @@ public class NotificacionesModulosService {
     }
 
     /**
-     * Verifica si hay notificaciones para el módulo MASTER_CONFIGS
+     * Verifica si hay notificaciones para el módulo MASTER_DIRECTIVES
      * @param user Usuario para el que se verifican las notificaciones
      * @return Objeto con información de notificación
      */
-    public ModuleNotificationDTA checkNotificacionesMasterConfigs(User user) {
+    public ModuleNotificationDTA checkNotificacionesMasterDirectives(User user) {
         ModuleNotificationDTA notification = new ModuleNotificationDTA();
-        notification.setModulo(Modulo.MASTER_CONFIGS);
+        notification.setModulo(Modulo.MASTER_DIRECTIVES);
         notification.setRequireAtention(false);
         notification.setMessage("");
         return notification;


### PR DESCRIPTION
## Summary
- rename MASTER_CONFIGS enum to MASTER_DIRECTIVES
- adjust notification service to match new enum

## Testing
- `./gradlew test`
- `psql -c "UPDATE accesos SET modulo_acceso = 'MASTER_DIRECTIVES' WHERE modulo_acceso = 'MASTER_CONFIGS';"` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68a8c4964ea08332bc836ba590babd18