### PR TITLE
feat: add fuzzy search for products

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/producto/MaterialRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/producto/MaterialRepo.java
@@ -1,12 +1,29 @@
 package lacosmetics.planta.lacmanufacture.repo.producto;
 
 import lacosmetics.planta.lacmanufacture.model.producto.Material;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MaterialRepo extends JpaRepository<Material, String>, JpaSpecificationExecutor<Material> {
-
-
+    @Query(value = """
+            SELECT * FROM productos p
+            WHERE p.tipo_producto = 'M'
+              AND similarity(p.nombre, :nombre) >= :threshold
+            ORDER BY similarity(p.nombre, :nombre) DESC
+            """,
+            countQuery = """
+            SELECT count(*) FROM productos p
+            WHERE p.tipo_producto = 'M'
+              AND similarity(p.nombre, :nombre) >= :threshold
+            """,
+            nativeQuery = true)
+    Page<Material> searchByNombreFuzzy(@Param("nombre") String nombre,
+                                       @Param("threshold") double threshold,
+                                       Pageable pageable);
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/producto/SemiTerminadoRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/producto/SemiTerminadoRepo.java
@@ -2,8 +2,12 @@ package lacosmetics.planta.lacmanufacture.repo.producto;
 
 import lacosmetics.planta.lacmanufacture.model.producto.Producto;
 import lacosmetics.planta.lacmanufacture.model.producto.SemiTerminado;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,5 +16,21 @@ import java.util.List;
 public interface SemiTerminadoRepo extends JpaRepository<SemiTerminado, String>, JpaSpecificationExecutor<SemiTerminado> {
 
     List<SemiTerminado> findByInsumos_Producto(Producto producto);
+
+    @Query(value = """
+            SELECT * FROM productos p
+            WHERE p.tipo_producto = 'S'
+              AND similarity(p.nombre, :nombre) >= :threshold
+            ORDER BY similarity(p.nombre, :nombre) DESC
+            """,
+            countQuery = """
+            SELECT count(*) FROM productos p
+            WHERE p.tipo_producto = 'S'
+              AND similarity(p.nombre, :nombre) >= :threshold
+            """,
+            nativeQuery = true)
+    Page<SemiTerminado> searchByNombreFuzzy(@Param("nombre") String nombre,
+                                            @Param("threshold") double threshold,
+                                            Pageable pageable);
 
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
@@ -85,14 +85,16 @@ public class ProductoResource {
             @RequestParam(value="page", defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam String search,
-            @RequestParam String tipoBusqueda) {
+            @RequestParam String tipoBusqueda,
+            @RequestParam(value = "fuzzy", defaultValue = "false") boolean fuzzy,
+            @RequestParam(value = "threshold", defaultValue = "0.3") double threshold) {
 
         // Si estamos en modo ID pero el parámetro 'search' está vacío,
         // redirigimos a la búsqueda por nombre (que hace LIKE "%%" y retorna todo).
         if ("ID".equalsIgnoreCase(tipoBusqueda)) {
             if (search == null || search.trim().isEmpty()) {
                 // -> devuelve todas las materias primas (paginadas)
-                Page<Material> todas = productoService.searchByName_MP("", page, size);
+                Page<Material> todas = productoService.searchByName_MP("", page, size, false, threshold);
                 return ResponseEntity.ok(todas);
             }
 
@@ -103,7 +105,7 @@ public class ProductoResource {
             return ResponseEntity.ok(resultado);
         } else {
             // Modo NOMBRE (incluye el caso search == "")
-            Page<Material> resultadoNombre = productoService.searchByName_MP(search, page, size);
+            Page<Material> resultadoNombre = productoService.searchByName_MP(search, page, size, fuzzy, threshold);
             return ResponseEntity.ok(resultadoNombre);
         }
     }
@@ -113,7 +115,9 @@ public class ProductoResource {
             @RequestParam(value="page", defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam String search,
-            @RequestParam String tipoBusqueda)
+            @RequestParam String tipoBusqueda,
+            @RequestParam(value = "fuzzy", defaultValue = "false") boolean fuzzy,
+            @RequestParam(value = "threshold", defaultValue = "0.3") double threshold)
     {
         if(tipoBusqueda.equals("ID")){
             Optional<SemiTerminado> semiTerminadoOptional = productoService.findSemiTerminadoByProductoId(search);
@@ -125,7 +129,7 @@ public class ProductoResource {
                 return ResponseEntity.ok().body(new PageImpl<>(List.of(), PageRequest.of(page, size), 0));
             }
         } else{
-            return ResponseEntity.ok().body(productoService.searchByName_S(search, page, size));
+            return ResponseEntity.ok().body(productoService.searchByName_S(search, page, size, fuzzy, threshold));
         }
     }
 
@@ -201,7 +205,7 @@ public class ProductoResource {
             pageResult = new PageImpl<>(result, PageRequest.of(page, size), result.size());
         } else {
             // Search by name
-            pageResult = productoService.searchByName_S(search, page, size);
+            pageResult = productoService.searchByName_S(search, page, size, false, 0.3);
         }
 
         Page<TargetDTO> dtoPage = pageResult.map(TargetDTO::fromProducto);

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/ProductoService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/productos/ProductoService.java
@@ -143,7 +143,10 @@ public class ProductoService {
         return terminadoRepo.findAll(PageRequest.of(page, size));
     }
 
-    public Page<Material> searchByName_MP(String searchTerm, int page, int size){
+    public Page<Material> searchByName_MP(String searchTerm, int page, int size, boolean fuzzy, double threshold){
+        if (fuzzy) {
+            return materialRepo.searchByNombreFuzzy(searchTerm, threshold, PageRequest.of(page, size));
+        }
         String[] searchTerms = searchTerm.toLowerCase().split(" ");
         Specification<Material> spec = (root, query, criteriaBuilder) -> {
             Predicate[] predicates = new Predicate[searchTerms.length];
@@ -158,7 +161,10 @@ public class ProductoService {
         return materialRepo.findAll(spec, PageRequest.of(page, size));
     }
 
-    public Page<SemiTerminado> searchByName_S(String searchTerm, int page, int size){
+    public Page<SemiTerminado> searchByName_S(String searchTerm, int page, int size, boolean fuzzy, double threshold){
+        if (fuzzy) {
+            return semiTerminadoRepo.searchByNombreFuzzy(searchTerm, threshold, PageRequest.of(page, size));
+        }
         String[] searchTerms = searchTerm.toLowerCase().split(" ");
 
         Specification<SemiTerminado> spec = (root, query, criteriaBuilder) -> {

--- a/src/main/resources/db/migration/V13__enable_pg_trgm_and_index_nombre_20250901.sql
+++ b/src/main/resources/db/migration/V13__enable_pg_trgm_and_index_nombre_20250901.sql
@@ -1,0 +1,3 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX IF NOT EXISTS idx_productos_nombre_trgm ON productos USING gin (nombre gin_trgm_ops);


### PR DESCRIPTION
## Summary
- add similarity-based search queries for materials and semi-finished products
- expose optional fuzzy search params in product search endpoints
- enable pg_trgm extension and index product names for faster fuzzy lookups

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a8cbfa16488332b9f9aa4ab1852ff7