### PR TITLE
feat: add observaciones to orden de compra

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/compras/OrdenCompraMateriales.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/compras/OrdenCompraMateriales.java
@@ -71,4 +71,7 @@ public class OrdenCompraMateriales {
 
     private double trm;
 
+    @Column(name = "observaciones")
+    private String observaciones;
+
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/commons/DocumentPdfService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/commons/DocumentPdfService.java
@@ -70,9 +70,9 @@ public class DocumentPdfService {
             
             // Add totals
             addTotals(document, orden);
-            
+
             // Add observations
-            addObservations(document);
+            addObservations(document, orden);
             
             document.close();
             
@@ -276,22 +276,21 @@ public class DocumentPdfService {
         document.add(Chunk.NEWLINE);
     }
     
-    private void addObservations(Document document) throws DocumentException {
+    private void addObservations(Document document, OrdenCompraMateriales orden) throws DocumentException {
         Font headerFont = new Font(Font.FontFamily.HELVETICA, 14, Font.NORMAL, new BaseColor(242, 220, 219));
-        
+
         Paragraph header = new Paragraph("OBSERVACIONES", headerFont);
         header.setAlignment(Element.ALIGN_LEFT);
         document.add(header);
-        
-        // Add empty space for observations
+
         PdfPTable table = new PdfPTable(1);
         table.setWidthPercentage(100);
-        
-        PdfPCell cell = new PdfPCell();
-        cell.setFixedHeight(100);
+
+        String obs = orden.getObservaciones() != null ? orden.getObservaciones() : "\n";
+        PdfPCell cell = new PdfPCell(new Phrase(obs));
         cell.setBorder(Rectangle.BOX);
         table.addCell(cell);
-        
+
         document.add(table);
     }
     

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/compras/ComprasService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/compras/ComprasService.java
@@ -354,6 +354,7 @@ public class ComprasService {
         // Actualizar los nuevos atributos de divisa y TRM
         ordenExistente.setDivisas(ordenCompraMateriales.getDivisas());
         ordenExistente.setTrm(ordenCompraMateriales.getTrm());
+        ordenExistente.setObservaciones(ordenCompraMateriales.getObservaciones());
 
         // No modificamos el estado ni la fecha de emisión aquí
         // Si se necesita cambiar el estado, se debe usar updateEstadoOrdenCompra

--- a/src/main/resources/db/migration/V14__add_observaciones_to_orden_compra.sql
+++ b/src/main/resources/db/migration/V14__add_observaciones_to_orden_compra.sql
@@ -1,0 +1,1 @@
+ALTER TABLE orden_compra ADD COLUMN observaciones TEXT;

--- a/src/test/resources/http/compras/orden-compra.http
+++ b/src/test/resources/http/compras/orden-compra.http
@@ -1,0 +1,27 @@
+### Variables globales
+@host = {{host}}
+@contentType = {{contentType}}
+
+# Nota: este archivo demuestra el uso del nuevo campo `observaciones`
+# en las operaciones de orden de compra.
+
+### Crear Orden de Compra con observaciones
+POST {{host}}/compras/save_orden_compra
+Content-Type: {{contentType}}
+Authorization: Bearer {{auth_token}}
+
+{
+  "fechaVencimiento": "2024-12-31T00:00:00",
+  "proveedor": {"id": 1},
+  "itemsOrdenCompra": [],
+  "subTotal": 0,
+  "ivaCOP": 0,
+  "totalPagar": 0,
+  "condicionPago": "contado",
+  "tiempoEntrega": "inmediato",
+  "plazoPago": 0,
+  "estado": 0,
+  "divisas": "COP",
+  "trm": 0,
+  "observaciones": "Observaciones de ejemplo"
+}


### PR DESCRIPTION
## Summary
- add `observaciones` column to `OrdenCompraMateriales`
- support observations in purchase order update service and PDF generator
- document HTTP example for purchase orders with observations

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a8d1cacfd48332b290ba0e5720ab25