### PR TITLE
feat: export inventory to Excel

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/InventarioExcelRequestDTO.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/dto/InventarioExcelRequestDTO.java
@@ -1,0 +1,15 @@
+package lacosmetics.planta.lacmanufacture.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class InventarioExcelRequestDTO {
+    private List<String> categories;
+    private String searchTerm;
+}

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/inventarios/InventarioResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/inventarios/InventarioResource.java
@@ -1,0 +1,29 @@
+package lacosmetics.planta.lacmanufacture.resource.inventarios;
+
+import lacosmetics.planta.lacmanufacture.model.dto.InventarioExcelRequestDTO;
+import lacosmetics.planta.lacmanufacture.service.inventarios.InventarioService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/inventario")
+@RequiredArgsConstructor
+public class InventarioResource {
+
+    private final InventarioService inventarioService;
+
+    @PostMapping("/exportar-excel")
+    public ResponseEntity<byte[]> exportarExcel(@RequestBody InventarioExcelRequestDTO dto) {
+        byte[] excel = inventarioService.generateInventoryExcel(dto);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"inventario.xlsx\"")
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(excel);
+    }
+}

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/inventarios/InventarioService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/inventarios/InventarioService.java
@@ -1,0 +1,81 @@
+package lacosmetics.planta.lacmanufacture.service.inventarios;
+
+import lacosmetics.planta.lacmanufacture.model.dto.InventarioExcelRequestDTO;
+import lacosmetics.planta.lacmanufacture.model.producto.Material;
+import lacosmetics.planta.lacmanufacture.model.producto.Producto;
+import lacosmetics.planta.lacmanufacture.model.producto.SemiTerminado;
+import lacosmetics.planta.lacmanufacture.model.producto.Terminado;
+import lacosmetics.planta.lacmanufacture.model.producto.dto.search.ProductoSearchCriteria;
+import lacosmetics.planta.lacmanufacture.repo.inventarios.TransaccionAlmacenRepo;
+import lacosmetics.planta.lacmanufacture.service.productos.ProductoService;
+import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.*;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class InventarioService {
+
+    private final ProductoService productoService;
+    private final TransaccionAlmacenRepo transaccionAlmacenRepo;
+
+    public byte[] generateInventoryExcel(InventarioExcelRequestDTO dto) {
+        Page<Producto> productos = productoService.consultaProductos(
+                dto.getSearchTerm(),
+                dto.getCategories(),
+                0,
+                Integer.MAX_VALUE
+        );
+
+        try (Workbook workbook = new XSSFWorkbook()) {
+            Sheet sheet = workbook.createSheet("Inventario");
+
+            Row headerRow = sheet.createRow(0);
+            headerRow.createCell(0).setCellValue("ID");
+            headerRow.createCell(1).setCellValue("Nombre");
+            headerRow.createCell(2).setCellValue("Categoría");
+            headerRow.createCell(3).setCellValue("Stock");
+
+            int rowIdx = 1;
+            for (Producto producto : productos.getContent()) {
+                Row row = sheet.createRow(rowIdx++);
+                row.createCell(0).setCellValue(producto.getProductoId());
+                row.createCell(1).setCellValue(producto.getNombre());
+                row.createCell(2).setCellValue(getCategoria(producto));
+                Double stock = transaccionAlmacenRepo.findTotalCantidadByProductoId(producto.getProductoId());
+                row.createCell(3).setCellValue(stock != null ? stock : 0);
+            }
+
+            for (int i = 0; i < 4; i++) {
+                sheet.autoSizeColumn(i);
+            }
+
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                workbook.write(out);
+                return out.toByteArray();
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error generating inventory Excel", e);
+        }
+    }
+
+    private String getCategoria(Producto producto) {
+        if (producto instanceof Material material) {
+            if (material.getTipoMaterial() == 1) {
+                return ProductoSearchCriteria.CATEGORIA_MATERIA_PRIMA;
+            } else if (material.getTipoMaterial() == 2) {
+                return ProductoSearchCriteria.CATEGORIA_MATERIAL_EMPAQUE;
+            }
+        } else if (producto instanceof SemiTerminado) {
+            return ProductoSearchCriteria.CATEGORIA_SEMITERMINADO;
+        } else if (producto instanceof Terminado) {
+            return ProductoSearchCriteria.CATEGORIA_TERMINADO;
+        }
+        return "";
+    }
+}


### PR DESCRIPTION
## Summary
- add DTO for inventory export request
- implement service to generate inventory Excel using Apache POI
- expose REST endpoint to download inventory as Excel

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a9e31564748332b8d8833d77797538