### PR TITLE
feat: export inventory movements to excel

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/model/inventarios/dto/MovimientoExcelRequestDTO.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/model/inventarios/dto/MovimientoExcelRequestDTO.java
@@ -1,0 +1,16 @@
+package lacosmetics.planta.lacmanufacture.model.inventarios.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class MovimientoExcelRequestDTO {
+    private String productoId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+}

--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
@@ -8,12 +8,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface TransaccionAlmacenRepo extends JpaRepository<Movimiento, Integer> {
 
     @Query("SELECT COALESCE(SUM(m.cantidad), 0) FROM Movimiento m WHERE m.producto.productoId = :productoId")
     Double findTotalCantidadByProductoId(@Param("productoId") String productoId);
+
+    @Query("SELECT COALESCE(SUM(m.cantidad), 0) FROM Movimiento m WHERE m.producto.productoId = :productoId AND m.fechaMovimiento < :fecha")
+    Double findTotalCantidadByProductoIdAndFechaMovimientoBefore(@Param("productoId") String productoId, @Param("fecha") LocalDateTime fecha);
 
     List<Movimiento> findMovimientosByCantidad(Double cantidad);
 
@@ -22,6 +26,8 @@ public interface TransaccionAlmacenRepo extends JpaRepository<Movimiento, Intege
 
     // New method
     Page<Movimiento> findByProducto_ProductoIdOrderByFechaMovimientoDesc(String productoId, Pageable pageable);
+
+    List<Movimiento> findByProducto_ProductoIdAndFechaMovimientoBetweenOrderByFechaMovimientoAsc(String productoId, LocalDateTime start, LocalDateTime end);
 
     /**
      * Encuentra lotes con stock disponible para un producto específico,

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/inventarios/MovimientosResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/inventarios/MovimientosResource.java
@@ -3,12 +3,14 @@ package lacosmetics.planta.lacmanufacture.resource.inventarios;
 
 import lacosmetics.planta.lacmanufacture.model.inventarios.dto.DispensacionDTO;
 import lacosmetics.planta.lacmanufacture.model.inventarios.dto.IngresoOCM_DTA;
+import lacosmetics.planta.lacmanufacture.model.inventarios.dto.MovimientoExcelRequestDTO;
 import lacosmetics.planta.lacmanufacture.model.inventarios.Movimiento;
 import lacosmetics.planta.lacmanufacture.model.inventarios.TransaccionAlmacen;
 import lacosmetics.planta.lacmanufacture.model.dto.ProductoStockDTO;
 import lacosmetics.planta.lacmanufacture.service.inventarios.MovimientosService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +33,15 @@ public class MovimientosResource {
     ) {
         Page<ProductoStockDTO> result = movimientoService.searchProductsWithStock(searchTerm, tipoBusqueda, page, size);
         return ResponseEntity.ok().body(result);
+    }
+
+    @PostMapping("/exportar-movimientos-excel")
+    public ResponseEntity<byte[]> exportMovimientosExcel(@RequestBody MovimientoExcelRequestDTO dto) {
+        byte[] excel = movimientoService.generateMovimientosExcel(dto);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"movimientos.xlsx\"")
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(excel);
     }
 
     // New endpoint to get movimientos for a product


### PR DESCRIPTION
## Summary
- add request DTO for inventory movement export
- expose Excel export endpoint for product movements
- generate workbook with initial total and movement list

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a9e4ff9a7c83328f11cd4995d52931