### PR TITLE
feat: expose MasterDirective lookup by nombre

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/master/configs/MasterDirectiveRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/master/configs/MasterDirectiveRepo.java
@@ -4,8 +4,10 @@ import lacosmetics.planta.lacmanufacture.model.master.configs.MasterDirective;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface MasterDirectiveRepo extends JpaRepository<MasterDirective, Long> {
     // Consultas personalizadas si son necesarias
-    MasterDirective findByNombre(String nombre);
+    Optional<MasterDirective> findByNombre(String nombre);
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/master/configs/MasterDirectiveResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/master/configs/MasterDirectiveResource.java
@@ -7,7 +7,12 @@ import lacosmetics.planta.lacmanufacture.service.master.configs.MasterDirectiveS
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Controlador REST para operaciones con directivas maestras de configuración
@@ -29,6 +34,13 @@ public class MasterDirectiveResource {
         log.info("REST request para obtener todas las directivas maestras");
         DTO_All_MasterDirectives masterDirectives = masterDirectiveService.getAllMasterDirectives();
         return ResponseEntity.ok(masterDirectives);
+    }
+
+    @GetMapping("/{nombre}")
+    public ResponseEntity<MasterDirective> getByNombre(@PathVariable String nombre) {
+        return masterDirectiveService.getByNombre(nombre)
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
     }
 
     /**

--- a/src/main/java/lacosmetics/planta/lacmanufacture/service/master/configs/MasterDirectiveService.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/service/master/configs/MasterDirectiveService.java
@@ -30,6 +30,10 @@ public class MasterDirectiveService {
         return new DTO_All_MasterDirectives(masterDirectives);
     }
 
+    public Optional<MasterDirective> getByNombre(String nombre) {
+        return masterDirectiveRepo.findByNombre(nombre);
+    }
+
     /**
      * Actualiza una directiva maestra
      * @param updateDTO DTO con la directiva original y la nueva directiva


### PR DESCRIPTION
## Summary
- allow looking up a MasterDirective by nombre using Optional repository method
- add service helper and REST endpoint for MasterDirective retrieval by nombre

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68add4b5411083328ec3ed99ce67761a