### PR TITLE
Add material deletion with dependency checks

### DIFF
--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/compras/ItemOrdenCompraRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/compras/ItemOrdenCompraRepo.java
@@ -1,0 +1,9 @@
+package lacosmetics.planta.lacmanufacture.repo.compras;
+
+import lacosmetics.planta.lacmanufacture.model.compras.ItemOrdenCompra;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemOrdenCompraRepo extends JpaRepository<ItemOrdenCompra, Integer> {
+    boolean existsByMaterial_ProductoId(String productoId);
+}
+

--- a/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/repo/inventarios/TransaccionAlmacenRepo.java
@@ -63,4 +63,6 @@ public interface TransaccionAlmacenRepo extends JpaRepository<Movimiento, Intege
                    "ORDER BY l.expiration_date ASC NULLS LAST", 
            nativeQuery = true)
     List<Object[]> findLotesWithStockByProductoIdNative(@Param("productoId") String productoId);
+
+    boolean existsByProducto_ProductoId(String productoId);
 }

--- a/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
+++ b/src/main/java/lacosmetics/planta/lacmanufacture/resource/productos/ProductoResource.java
@@ -271,4 +271,15 @@ public class ProductoResource {
         }
     }
 
+    @DeleteMapping("/{productoId}")
+    public ResponseEntity<Object> deleteMaterial(@PathVariable String productoId) {
+        try {
+            productoService.deleteMaterial(productoId);
+            return ResponseEntity.noContent().build();
+        } catch (IllegalStateException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT)
+                    .body(Map.of("error", e.getMessage()));
+        }
+    }
+
 }


### PR DESCRIPTION
## Summary
- add ItemOrdenCompraRepo with method to detect purchase order references
- extend TransaccionAlmacenRepo to detect inventory movements
- allow ProductoService and ProductoResource to delete materials only when no references exist

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68b0a39799b08332b0561fd72d7be8ff